### PR TITLE
Bloquear login caso e-mail não tenha sido verificado

### DIFF
--- a/src/main/java/com/portal/centro/API/security/filters/JWTAuthenticationFilter.java
+++ b/src/main/java/com/portal/centro/API/security/filters/JWTAuthenticationFilter.java
@@ -38,14 +38,22 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             User credentials = new ObjectMapper().readValue(request.getInputStream(), User.class);
             User user = (User) authService.loadUserByUsername(credentials.getEmail());
 
-            return authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(
-                            credentials.getEmail(),
-                            credentials.getPassword(),
-                            user.getAuthorities()
-                    )
-            );
+            if(user.getEmailVerified() == null || !user.getEmailVerified()){
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Email not verified");
+                return null;
+            }else{
+                return authenticationManager.authenticate(
+                        new UsernamePasswordAuthenticationToken(
+                                credentials.getEmail(),
+                                credentials.getPassword(),
+                                user.getAuthorities()
+                        )
+                );
+            }
         } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -65,5 +73,4 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 new AuthenticationResponse(token, new UserLoginDTO((User) authResult.getPrincipal()))
         ));
     }
-
 }


### PR DESCRIPTION
Foi adicionado uma verificação para saber se o e-mail já foi verificado. Caso o campo esteja nulo ou false é retornado uma resposta para o client informando que o e-mail não foi verificado, podendo assim filtrar a resposta e informar o erro para o usuário.

Link da tarefa: [segue o link](https://trello.com/c/iF1mxko7/26-bloquear-login-quando-e-mail-n%C3%A3o-ta-verificado)