### PR TITLE
Solicitar novo e-mail de verificação de e-mail

### DIFF
--- a/src/main/java/com/portal/centro/API/controller/EmailConfirmController.java
+++ b/src/main/java/com/portal/centro/API/controller/EmailConfirmController.java
@@ -1,22 +1,24 @@
 package com.portal.centro.API.controller;
 
+import com.portal.centro.API.dto.RequestCodeEmailDto;
+import com.portal.centro.API.model.User;
 import com.portal.centro.API.service.EmailCodeService;
+import com.portal.centro.API.service.UserService;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import javax.websocket.server.PathParam;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("emailconfirm")
 public class EmailConfirmController {
 
     final EmailCodeService emailCodeService;
+    final UserService userService;
 
-    public EmailConfirmController(EmailCodeService emailCodeService) {
+    public EmailConfirmController(EmailCodeService emailCodeService, UserService userService) {
         this.emailCodeService = emailCodeService;
+        this.userService = userService;
     }
 
     @GetMapping("code/{code}")
@@ -24,5 +26,15 @@ public class EmailConfirmController {
         return ResponseEntity.ok(this.emailCodeService.confirmEmail(hash));
     }
 
+    @PostMapping("/request_verification")
+    public ResponseEntity requestVerification(@NotNull @RequestBody RequestCodeEmailDto emailDto) throws Exception {
+        User user = userService.findByEmail(emailDto.getEmail());
 
+        if(user != null) {
+            this.emailCodeService.createCode(user);
+            return ResponseEntity.ok("send email");
+        }
+
+        return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
 }

--- a/src/main/java/com/portal/centro/API/dto/RequestCodeEmailDto.java
+++ b/src/main/java/com/portal/centro/API/dto/RequestCodeEmailDto.java
@@ -1,0 +1,12 @@
+package com.portal.centro.API.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Null;
+
+@Data
+public class RequestCodeEmailDto {
+    @Email
+    private String email;
+}

--- a/src/main/java/com/portal/centro/API/security/WebSecurity.java
+++ b/src/main/java/com/portal/centro/API/security/WebSecurity.java
@@ -49,6 +49,7 @@ public class WebSecurity {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/users/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/emailconfirm/**").permitAll()
+                .antMatchers(HttpMethod.POST, "/emailconfirm/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .authenticationManager(authenticationManager)

--- a/src/main/java/com/portal/centro/API/service/UserService.java
+++ b/src/main/java/com/portal/centro/API/service/UserService.java
@@ -158,6 +158,10 @@ public class UserService extends GenericService<User, Long> {
         return user;
     }
 
+    public User findByEmail(@PathVariable("email") String email){
+        return this.userRepository.findByEmail(email);
+    }
+
     public List<User> findUsersByRole(@PathVariable("role") String role) {
         Type type;
         try {


### PR DESCRIPTION
Este PR adicionar um novo endpoint para solicitar um novo e-mail de verificação.

Essa funcionalidade pode ser usada quando o e-mail de verificação fica perdido na caixa de entrada, dessa forma o usuário pode solicitar um novo e-mail no momento em que está tentando fazer login na aplicação.

Link da tarefa: [segue o link](https://trello.com/c/oP44xoca/20-solicitar-novo-e-mail-de-verifica%C3%A7%C3%A3o)