### PR TITLE
Novos usuários com status null

### DIFF
--- a/src/main/java/com/portal/centro/API/service/UserService.java
+++ b/src/main/java/com/portal/centro/API/service/UserService.java
@@ -68,6 +68,7 @@ public class UserService extends GenericService<User, Long> {
         Type role = utilsService.getRoleType(requestBody.getEmail());
         requestBody.setPermissions(utilsService.getPermissionsByRole(role));
         requestBody.setRole(role);
+        requestBody.setStatus(StatusInactiveActive.ACTIVE);
         this.validate(requestBody);
         User user = super.save(requestBody);
         this.emailCodeService.createCode(user);

--- a/src/main/java/com/portal/centro/API/service/UserService.java
+++ b/src/main/java/com/portal/centro/API/service/UserService.java
@@ -79,6 +79,7 @@ public class UserService extends GenericService<User, Long> {
     public User saveAdmin(User requestBody) throws Exception {
         encryptPassword(requestBody);
         requestBody.setPermissions(utilsService.getPermissionsByRole(requestBody.getRole()));
+        requestBody.setStatus(StatusInactiveActive.ACTIVE);
         this.validate(requestBody);
         User user = super.save(requestBody);
         this.emailCodeService.createCode(user);


### PR DESCRIPTION
Foi ajustado para que novos usuários sejam cadastrados com status 1(ACTIVE);
A alteração foi necessária pois após cadastrar a pessoa a mesma não aparecia na lista de usuários da rotina de admin;
A coluna status é referente se o usuário está ativo ou não, de qualquer forma, após ser cadastrado o mesmo deverá verificar seu email para poder logar no sistema.