### PR TITLE
fix(validar email): adicionar o datetime na geração do código

### DIFF
--- a/src/main/java/com/portal/centro/API/service/EmailCodeService.java
+++ b/src/main/java/com/portal/centro/API/service/EmailCodeService.java
@@ -39,7 +39,7 @@ public class EmailCodeService extends GenericService<EmailCode, Long> {
 
     public EmailCode createCode(User user) throws Exception {
         LocalDateTime dateTime = LocalDateTime.now();
-        String hashKey = this.hashingService.generateHashKey(user.getEmail());
+        String hashKey = this.hashingService.generateHashKey(user.getEmail() + dateTime);
 
         EmailCode emailCode = EmailCode.builder().code(hashKey).user(user).createdAt(dateTime).build();
 


### PR DESCRIPTION
Quando solicitava mais de um e-mail para validar o e-mail a validação não funcionava, isso acontecia por conta do hash que era gerado (sempre gerava o mesmo hash), adicionando o datetime corrente faz com que nunca seja gerado o mesmo código.

Link da tarefa: [segue o link](https://trello.com/c/F5TqaUYj/56-bug-ao-solicitar-reenvio-de-confirma%C3%A7%C3%A3o-duas-vezes-est%C3%A1-duplicando-os-registros-no-banco-de-dados-e-caso-isso-aconte%C3%A7a-o-usu%C3%A1rio)