### PR TITLE
Professor do projeto sendo alterado

### DIFF
--- a/src/main/java/com/portal/centro/API/model/Project.java
+++ b/src/main/java/com/portal/centro/API/model/Project.java
@@ -26,7 +26,7 @@ public class Project extends IModel {
     private String subject;
 
     @ManyToOne
-    @JoinColumn(name = "teacher_id")
+    @JoinColumn(name = "teacher_id", updatable = false)
     private User teacher;
 
     @ManyToMany


### PR DESCRIPTION
Explicação do problema: Ao utilizar um usuário Admin para editar um projeto de outro professor, o usuário do Admin passava a ser o dono do projeto.
Quando um projeto for criado por um professor, o mesmo será sempre do mesmo professor. Como solução foi adicionada a propriedade updatable = false para o campo teacher da classe Project;