### PR TITLE
Histórico trazendo histórico de outras solicitações

### DIFF
--- a/src/main/java/com/portal/centro/API/repository/AuditRepository.java
+++ b/src/main/java/com/portal/centro/API/repository/AuditRepository.java
@@ -7,7 +7,6 @@ import com.portal.centro.API.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,7 +20,7 @@ public interface AuditRepository extends GenericRepository<Audit, Long> {
 
     List<Audit> findAllBySolicitation_CreatedByOrSolicitation_Project_Teacher(User user, User teacher);
     Page<Audit> findAllBySolicitation_CreatedByOrSolicitation_Project_Teacher(User user, User teacher, PageRequest pageRequest);
-    List<Audit> findAllBySolicitation_CreatedByOrSolicitation_Project_TeacherAndSolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(User user, User teacher, Long id, SolicitationStatus newStatus);
+    List<Audit> findAllBySolicitation_Project_TeacherAndSolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(User teacher, Long id, SolicitationStatus newStatus);
 
     List<Audit> findAllBySolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(Long id, SolicitationStatus newStatus);
 

--- a/src/main/java/com/portal/centro/API/service/AuditService.java
+++ b/src/main/java/com/portal/centro/API/service/AuditService.java
@@ -55,7 +55,7 @@ public class AuditService extends GenericService<Audit, Long> {
             case ROLE_PARTNER:
                 return auditRepository.findAllBySolicitation_CreatedByAndSolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(user, id, status);
             case ROLE_PROFESSOR:
-                return auditRepository.findAllBySolicitation_CreatedByOrSolicitation_Project_TeacherAndSolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(user, user, id, status);
+                return auditRepository.findAllBySolicitation_Project_TeacherAndSolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(user, id, status);
             case ROLE_ADMIN:
                 return auditRepository.findAllBySolicitationIdAndNewStatusIsNotOrderByChangeDateDesc(id, status);
             default:


### PR DESCRIPTION
Ajustada a busca de histórico para professores quando é expandido o histórico de uma solicitação para visualizar os status anteriores.
A busca estava trazendo não só as solicitações corretas mas também as que o professor estava vinculado.